### PR TITLE
feat(dedupe): add support for multi-valued fields

### DIFF
--- a/components/artists/dedupe/manager/ArtistCard.tsx
+++ b/components/artists/dedupe/manager/ArtistCard.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch } from "react"
 
 import { Artist } from "../types"
 import { Action, RecordStatus, State } from "./state"
-import { ArtistCardField } from "./ArtistCardField"
+import { ArtistCardField, FieldType } from "./ArtistCardField"
 import { ArtistCardHeader } from "./ArtistCardHeader"
 
 interface Props {
@@ -17,6 +17,9 @@ interface Props {
 
   /** Overrides to values in the good record */
   overrides?: State["overrides"]
+
+  /** Addditions to values in the good record */
+  additions?: State["additions"]
 
   /** Top-level dispatch function. */
   dispatch?: Dispatch<Action>
@@ -36,7 +39,7 @@ export type ArtistCardMode = "select records" | "select fields"
  */
 
 export const ArtistCard: React.FC<Props> = (props) => {
-  const { artist, recordStatus, mode, overrides, dispatch } = props
+  const { artist, recordStatus, mode, overrides, additions, dispatch } = props
 
   return (
     <div className="[min-width:15em]">
@@ -48,6 +51,7 @@ export const ArtistCard: React.FC<Props> = (props) => {
       <ArtistCardField
         fieldName="gender"
         fieldValue={artist.gender}
+        fieldType={FieldType.SINGLE}
         mode={mode}
         overrides={overrides}
         recordId={artist.internalID}
@@ -58,6 +62,7 @@ export const ArtistCard: React.FC<Props> = (props) => {
       <ArtistCardField
         fieldName="nationality"
         fieldValue={artist.nationality}
+        fieldType={FieldType.SINGLE}
         mode={mode}
         overrides={overrides}
         recordId={artist.internalID}
@@ -68,6 +73,7 @@ export const ArtistCard: React.FC<Props> = (props) => {
       <ArtistCardField
         fieldName="birthday"
         fieldValue={artist.birthday}
+        fieldType={FieldType.SINGLE}
         mode={mode}
         overrides={overrides}
         recordId={artist.internalID}
@@ -78,6 +84,7 @@ export const ArtistCard: React.FC<Props> = (props) => {
       <ArtistCardField
         fieldName="deathday"
         fieldValue={artist.deathday}
+        fieldType={FieldType.SINGLE}
         mode={mode}
         overrides={overrides}
         recordId={artist.internalID}
@@ -88,6 +95,7 @@ export const ArtistCard: React.FC<Props> = (props) => {
       <ArtistCardField
         fieldName="hometown"
         fieldValue={artist.hometown}
+        fieldType={FieldType.SINGLE}
         mode={mode}
         overrides={overrides}
         recordId={artist.internalID}
@@ -98,8 +106,33 @@ export const ArtistCard: React.FC<Props> = (props) => {
       <ArtistCardField
         fieldName="location"
         fieldValue={artist.location}
+        fieldType={FieldType.SINGLE}
         mode={mode}
         overrides={overrides}
+        recordId={artist.internalID}
+        recordStatus={recordStatus || RecordStatus.UNKNOWN}
+        dispatch={dispatch}
+      />
+
+      <div className={`p-0.5 border border-black30 bg-black30`} />
+
+      <ArtistCardField
+        fieldName="artworks"
+        fieldValue={artist.counts.artworks}
+        fieldType={FieldType.MULTIPLE}
+        mode={mode}
+        additions={additions}
+        recordId={artist.internalID}
+        recordStatus={recordStatus || RecordStatus.UNKNOWN}
+        dispatch={dispatch}
+      />
+
+      <ArtistCardField
+        fieldName="follows"
+        fieldValue={artist.counts.follows}
+        fieldType={FieldType.MULTIPLE}
+        mode={mode}
+        additions={additions}
         recordId={artist.internalID}
         recordStatus={recordStatus || RecordStatus.UNKNOWN}
         dispatch={dispatch}

--- a/components/artists/dedupe/manager/ArtistCard.tsx
+++ b/components/artists/dedupe/manager/ArtistCard.tsx
@@ -22,7 +22,7 @@ interface Props {
   dispatch?: Dispatch<Action>
 }
 
-/** The different affordances the card can offer: select whole record, or select invidual fields.  */
+/** The different affordances the card can offer: select whole record, or select individual fields.  */
 export type ArtistCardMode = "select records" | "select fields"
 
 /**

--- a/components/artists/dedupe/manager/ArtistCardFieldMultiSelect.tsx
+++ b/components/artists/dedupe/manager/ArtistCardFieldMultiSelect.tsx
@@ -1,0 +1,85 @@
+import React, { Dispatch } from "react"
+import { BsonID } from "../types"
+import { Action, RecordStatus, MultiValuedField, State } from "./state"
+
+interface Props {
+  fieldName: MultiValuedField
+  fieldValue: string | number
+  additions: State["additions"]
+  recordId: BsonID
+  recordStatus: RecordStatus
+  dispatch: Dispatch<Action>
+}
+
+export const ArtistCardFieldMultiSelect: React.FC<Props> = (props) => {
+  const { fieldName, fieldValue, additions, recordId, recordStatus, dispatch } =
+    props
+
+  const { bgColor, isIncluded } = getVisualState({
+    fieldName,
+    additions,
+    recordId,
+    recordStatus,
+  })
+
+  return (
+    <button
+      className="block group text-left w-full hover:shadow-lg focus:shadow-lg"
+      onClick={() => {
+        if (additions[fieldName].includes(recordId)) {
+          // a previous addition is being undone
+          dispatch({
+            type: "remove value",
+            fieldName: fieldName as MultiValuedField,
+            recordId,
+          })
+        } else if (recordStatus === RecordStatus.BAD) {
+          // a field from a "bad" record is being added
+          dispatch({
+            type: "add value",
+            fieldName: fieldName as MultiValuedField,
+            recordId,
+          })
+        }
+      }}
+    >
+      <div
+        className={`p-2 border border-t-0 group-last:rounded-b-lg border-black30 ${bgColor} hover:bg-green5`}
+      >
+        <div className="text-xs text-black50">{fieldName}</div>
+        <div className="[min-height:2em]">
+          {isIncluded ? <strong>{fieldValue}</strong> : fieldValue}
+        </div>
+      </div>
+    </button>
+  )
+}
+
+/**
+ * A field from a "bad" record can be merged into a field from a "good" record.
+ *
+ * The UI should reflect that.
+ */
+
+export function getVisualState(args: {
+  fieldName: MultiValuedField
+  additions: State["additions"]
+  recordId: BsonID
+  recordStatus: RecordStatus
+}): VisualState {
+  const { fieldName, additions, recordId, recordStatus } = args
+
+  const isGood = recordStatus === RecordStatus.GOOD
+  const isMerged = additions[fieldName]?.includes(recordId)
+  const isIncluded = isGood || isMerged
+
+  let bgColor = "bg-white100" // ignored
+  if (isIncluded) bgColor = "bg-green5"
+
+  return { bgColor, isIncluded }
+}
+
+interface VisualState {
+  bgColor: string
+  isIncluded: boolean
+}

--- a/components/artists/dedupe/manager/ArtistCardFieldMultiSelect.tsx
+++ b/components/artists/dedupe/manager/ArtistCardFieldMultiSelect.tsx
@@ -12,8 +12,7 @@ interface Props {
 }
 
 export const ArtistCardFieldMultiSelect: React.FC<Props> = (props) => {
-  const { fieldName, fieldValue, additions, recordId, recordStatus, dispatch } =
-    props
+  const { fieldName, fieldValue, additions, recordId, recordStatus } = props
 
   const { bgColor, isIncluded } = getVisualState({
     fieldName,
@@ -23,35 +22,40 @@ export const ArtistCardFieldMultiSelect: React.FC<Props> = (props) => {
   })
 
   return (
-    <button
-      className="block group text-left w-full hover:shadow-lg focus:shadow-lg"
-      onClick={() => {
-        if (additions[fieldName].includes(recordId)) {
-          // a previous addition is being undone
-          dispatch({
-            type: "remove value",
-            fieldName: fieldName as MultiValuedField,
-            recordId,
-          })
-        } else if (recordStatus === RecordStatus.BAD) {
-          // a field from a "bad" record is being added
-          dispatch({
-            type: "add value",
-            fieldName: fieldName as MultiValuedField,
-            recordId,
-          })
-        }
-      }}
+    /**
+     * after discussing with stakeholder, disabling this toggle functionality for now, since it might just produced orphaned data
+     */
+
+    // <button
+    //   className="block group text-left w-full hover:shadow-lg focus:shadow-lg"
+    //   onClick={() => {
+    //     if (additions[fieldName].includes(recordId)) {
+    //       // a previous addition is being undone
+    //       dispatch({
+    //         type: "remove value",
+    //         fieldName: fieldName as MultiValuedField,
+    //         recordId,
+    //       })
+    //     } else if (recordStatus === RecordStatus.BAD) {
+    //       // a field from a "bad" record is being added
+    //       dispatch({
+    //         type: "add value",
+    //         fieldName: fieldName as MultiValuedField,
+    //         recordId,
+    //       })
+    //     }
+    //     */
+    //   }}
+    // >
+    <div
+      className={`p-2 border border-t-0 group-last:rounded-b-lg border-black30 ${bgColor} hover:bg-green5`}
     >
-      <div
-        className={`p-2 border border-t-0 group-last:rounded-b-lg border-black30 ${bgColor} hover:bg-green5`}
-      >
-        <div className="text-xs text-black50">{fieldName}</div>
-        <div className="[min-height:2em]">
-          {isIncluded ? <strong>{fieldValue}</strong> : fieldValue}
-        </div>
+      <div className="text-xs text-black50">{fieldName}</div>
+      <div className="[min-height:2em]">
+        {isIncluded ? <strong>{fieldValue}</strong> : fieldValue}
       </div>
-    </button>
+    </div>
+    // </button>
   )
 }
 

--- a/components/artists/dedupe/manager/ArtistCardFieldSingleSelect.tsx
+++ b/components/artists/dedupe/manager/ArtistCardFieldSingleSelect.tsx
@@ -1,0 +1,102 @@
+import React, { Dispatch } from "react"
+import { BsonID } from "../types"
+import { Action, RecordStatus, SingleValuedField, State } from "./state"
+
+interface Props {
+  fieldName: SingleValuedField
+  fieldValue: string | number
+  overrides: State["overrides"]
+  recordId: BsonID
+  recordStatus: RecordStatus
+  dispatch: Dispatch<Action>
+}
+
+export const ArtistCardFieldSingleSelect: React.FC<Props> = (props) => {
+  const { fieldName, fieldValue, overrides, recordId, recordStatus, dispatch } =
+    props
+
+  const { bgColor, isOverridenValue, isPreferredValue } = getVisualState({
+    fieldName,
+    overrides,
+    recordId,
+    recordStatus,
+  })
+
+  return (
+    <button
+      className="block group text-left w-full hover:shadow-lg focus:shadow-lg"
+      onClick={() => {
+        if (recordStatus == RecordStatus.GOOD) {
+          // a previous override is being undone
+          dispatch({
+            type: "prefer value",
+            fieldName: fieldName as SingleValuedField,
+            recordId: null,
+          })
+        } else {
+          // a new override is being created
+          dispatch({
+            type: "prefer value",
+            fieldName: fieldName as SingleValuedField,
+            recordId,
+          })
+        }
+      }}
+    >
+      <div
+        className={`p-2 border border-t-0 group-last:rounded-b-lg border-black30 ${bgColor} hover:bg-green5`}
+      >
+        <div className="text-xs text-black50">{fieldName}</div>
+        <div className="[min-height:2em]">
+          {isOverridenValue ? (
+            <del>{fieldValue}</del>
+          ) : isPreferredValue ? (
+            <strong>{fieldValue}</strong>
+          ) : (
+            fieldValue
+          )}
+        </div>
+      </div>
+    </button>
+  )
+}
+
+/**
+ * A field from a "bad" record can be preferred,
+ * and thus override a field from a "good" record.
+ *
+ * The UI should reflect that.
+ */
+
+export function getVisualState(args: {
+  fieldName: SingleValuedField
+  overrides: State["overrides"]
+  recordId: BsonID
+  recordStatus: RecordStatus
+}): VisualState {
+  const { fieldName, overrides, recordId, recordStatus } = args
+
+  // does this field have an override in some record?
+  const isFieldOveridden = Boolean(overrides[fieldName])
+
+  // is this the "bad" record that is overriding this field's value?
+  const isPreferredValue = overrides[fieldName] === recordId
+
+  // is this the "good" record whose value in this field is getting overridden?
+  const isOverridenValue = Boolean(
+    recordStatus === RecordStatus.GOOD && isFieldOveridden
+  )
+
+  let bgColor = "bg-white100" // ignored
+  if (isOverridenValue) bgColor = "bg-red5" // overridden
+  if (isPreferredValue) bgColor = "bg-green5" // preferred
+  if (recordStatus === RecordStatus.GOOD && !isFieldOveridden)
+    bgColor = "bg-green5" // still good
+
+  return { bgColor, isOverridenValue, isPreferredValue }
+}
+interface VisualState {
+  bgColor: string
+  isOverridenValue: boolean
+  isPreferredValue: boolean
+}

--- a/components/artists/dedupe/manager/Debug.tsx
+++ b/components/artists/dedupe/manager/Debug.tsx
@@ -6,6 +6,8 @@ import { State } from "./state"
 
 /**
  * Lil helper for examining the app's current state as well as its original incoming data (the artist prop)
+ *
+ * Can be activated by appending ?debug to the url
  */
 export const Debug = ({ artist, state }: { artist: Artist; state: State }) => {
   const router = useRouter()

--- a/components/artists/dedupe/manager/SelectFields.tsx
+++ b/components/artists/dedupe/manager/SelectFields.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch } from "react"
+import React, { Dispatch, useEffect } from "react"
 import { Action, getRecordStatus, State } from "./state"
 import { Feedback } from "./Feedback"
 import { Progress } from "./Progress"
@@ -13,6 +13,14 @@ interface Props {
  * Third step: choose values from the "bad" record(s) to override the "good" ones
  */
 export const SelectFields: React.FC<Props> = ({ state, dispatch }) => {
+  useEffect(() => {
+    // on mount, assume we will add all relations from bad records
+    state.badIds.map((id) => {
+      dispatch({ type: "add value", fieldName: "artworks", recordId: id })
+      dispatch({ type: "add value", fieldName: "follows", recordId: id })
+    })
+  }, [state.badIds, dispatch])
+
   return (
     <div>
       <Progress state={state} dispatch={dispatch} />
@@ -27,6 +35,7 @@ export const SelectFields: React.FC<Props> = ({ state, dispatch }) => {
                 mode="select fields"
                 recordStatus={getRecordStatus(state, dupe)}
                 overrides={state.overrides}
+                additions={state.additions}
                 dispatch={dispatch}
               />
             </div>

--- a/components/artists/dedupe/manager/__fixtures__/artist-with-dupes.ts
+++ b/components/artists/dedupe/manager/__fixtures__/artist-with-dupes.ts
@@ -10,6 +10,10 @@ const artistWithDupes: ArtistWithDupes = {
   deathday: "",
   hometown: "",
   location: "",
+  counts: {
+    artworks: 17,
+    follows: 3,
+  },
   duplicates: [
     {
       internalID: "61d6b75c67697a000b16ce43",
@@ -21,6 +25,10 @@ const artistWithDupes: ArtistWithDupes = {
       deathday: "",
       hometown: "",
       location: "",
+      counts: {
+        artworks: 17,
+        follows: 3,
+      },
     },
     {
       internalID: "5c33c6856196a57e5255e29e",
@@ -32,6 +40,10 @@ const artistWithDupes: ArtistWithDupes = {
       deathday: "1978",
       hometown: "Long Island, New York, USA",
       location: "",
+      counts: {
+        artworks: 42,
+        follows: 420,
+      },
     },
     {
       internalID: "5cae0291e398462d85c1387f",
@@ -43,6 +55,10 @@ const artistWithDupes: ArtistWithDupes = {
       deathday: "",
       hometown: "Madison, WI, USA",
       location: "New York, NY, USA",
+      counts: {
+        artworks: 12,
+        follows: 10,
+      },
     },
   ],
 }

--- a/components/artists/dedupe/manager/__tests__/ArtistCard.spec.tsx
+++ b/components/artists/dedupe/manager/__tests__/ArtistCard.spec.tsx
@@ -25,6 +25,12 @@ it("displays labels and values", () => {
 
   expect(screen.getByText("deathday")).toBeInTheDocument()
   expect(screen.getByText("1978")).toBeInTheDocument()
+
+  expect(screen.getByText("artworks")).toBeInTheDocument()
+  expect(screen.getByText("42")).toBeInTheDocument()
+
+  expect(screen.getByText("follows")).toBeInTheDocument()
+  expect(screen.getByText("420")).toBeInTheDocument()
 })
 
 it("displays label even when value is not present", () => {

--- a/components/artists/dedupe/manager/__tests__/ArtistCardField.spec.tsx
+++ b/components/artists/dedupe/manager/__tests__/ArtistCardField.spec.tsx
@@ -58,7 +58,7 @@ describe("when mode is 'select fields'", () => {
   })
 
   describe("when the field is multi-valued", () => {
-    it("displays the field name and value as a clickable element", () => {
+    xit("displays the field name and value as a clickable element", () => {
       render(
         <ArtistCardField
           fieldName="artworks"

--- a/components/artists/dedupe/manager/__tests__/ArtistCardField.spec.tsx
+++ b/components/artists/dedupe/manager/__tests__/ArtistCardField.spec.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch } from "react"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
-import { ArtistCardField } from "../ArtistCardField"
+import { ArtistCardField, FieldType } from "../ArtistCardField"
 import { Action, initialState, RecordStatus } from "../state"
 
 describe("when mode is 'select records'", () => {
@@ -10,6 +10,7 @@ describe("when mode is 'select records'", () => {
     render(
       <ArtistCardField
         fieldName="birthday"
+        fieldType={FieldType.SINGLE}
         fieldValue="1950"
         mode="select records"
         recordId="foobar"
@@ -29,27 +30,57 @@ describe("when mode is 'select fields'", () => {
     dispatch = jest.fn()
   })
 
-  it("displays the field name and value as a clickable element", () => {
-    render(
-      <ArtistCardField
-        fieldName="birthday"
-        fieldValue="1950"
-        mode="select fields"
-        recordId="foobar"
-        recordStatus={RecordStatus.UNKNOWN}
-        overrides={initialState.overrides}
-        dispatch={dispatch}
-      />
-    )
+  describe("when the field is single-valued", () => {
+    it("displays the field name and value as a clickable element", () => {
+      render(
+        <ArtistCardField
+          fieldName="birthday"
+          fieldType={FieldType.SINGLE}
+          fieldValue="1950"
+          mode="select fields"
+          recordId="foobar"
+          recordStatus={RecordStatus.UNKNOWN}
+          overrides={initialState.overrides}
+          dispatch={dispatch}
+        />
+      )
 
-    expect(screen.getByText("birthday")).toBeInTheDocument()
-    expect(screen.getByText("1950")).toBeInTheDocument()
+      expect(screen.getByText("birthday")).toBeInTheDocument()
+      expect(screen.getByText("1950")).toBeInTheDocument()
 
-    userEvent.click(screen.getByRole("button"))
-    expect(dispatch).toHaveBeenCalledWith({
-      type: "prefer value",
-      fieldName: "birthday",
-      recordId: "foobar",
-    } as Action)
+      userEvent.click(screen.getByRole("button"))
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "prefer value",
+        fieldName: "birthday",
+        recordId: "foobar",
+      } as Action)
+    })
+  })
+
+  describe("when the field is multi-valued", () => {
+    it("displays the field name and value as a clickable element", () => {
+      render(
+        <ArtistCardField
+          fieldName="artworks"
+          fieldType={FieldType.MULTIPLE}
+          fieldValue="42"
+          mode="select fields"
+          recordId="foobar"
+          recordStatus={RecordStatus.BAD}
+          additions={initialState.additions}
+          dispatch={dispatch}
+        />
+      )
+
+      expect(screen.getByText("artworks")).toBeInTheDocument()
+      expect(screen.getByText("42")).toBeInTheDocument()
+
+      userEvent.click(screen.getByRole("button"))
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "add value",
+        fieldName: "artworks",
+        recordId: "foobar",
+      } as Action)
+    })
   })
 })

--- a/components/artists/dedupe/manager/__tests__/Feedback.spec.tsx
+++ b/components/artists/dedupe/manager/__tests__/Feedback.spec.tsx
@@ -68,6 +68,10 @@ const defaultState: State = {
     hometown: null,
     location: null,
   },
+  additions: {
+    artworks: [],
+    follows: [],
+  },
   artist: artistAttrs,
   dupes: duplicates,
 }

--- a/components/artists/dedupe/manager/__tests__/SelectFields.spec.tsx
+++ b/components/artists/dedupe/manager/__tests__/SelectFields.spec.tsx
@@ -18,3 +18,25 @@ it("renders a (non-clickable) card for each dupe", () => {
   expect(screen.getByText(/warren-king-1/)).toBeInTheDocument()
   expect(screen.getByText(/warren-king$/)).toBeInTheDocument()
 })
+
+it("upon mount, dispactches actions to add values from bad records' multi-valued fields", () => {
+  const dispatch = jest.fn()
+  render(
+    <SelectFields
+      state={{
+        ...initialState,
+        badIds: ["foo", "bar"],
+        dupes: artist.duplicates,
+      }}
+      dispatch={dispatch}
+    />
+  )
+
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "add value",
+      fieldName: expect.anything(),
+      recordId: "foo",
+    })
+  )
+})

--- a/components/artists/dedupe/manager/__tests__/state.spec.tsx
+++ b/components/artists/dedupe/manager/__tests__/state.spec.tsx
@@ -112,6 +112,42 @@ describe("actions", () => {
       expect(state.overrides.nationality).toEqual("foobar")
     })
   })
+
+  describe("add value", () => {
+    it("marks a record as adding to the given field", () => {
+      const previousState: State = initialState
+      const action: Action = {
+        type: "add value",
+        fieldName: "follows",
+        recordId: "foobar",
+      }
+
+      const state = reducer(previousState, action)
+
+      expect(state.additions.follows).toContain("foobar")
+    })
+  })
+
+  describe("remove value", () => {
+    it("unmarks a record as adding to the given field", () => {
+      const previousState: State = {
+        ...initialState,
+        additions: {
+          ...initialState.additions,
+          follows: ["foobar"],
+        },
+      }
+      const action: Action = {
+        type: "remove value",
+        fieldName: "follows",
+        recordId: "foobar",
+      }
+
+      const state = reducer(previousState, action)
+
+      expect(state.additions.follows).not.toContain("foobar")
+    })
+  })
 })
 
 describe(getRecordStatus, () => {

--- a/components/artists/dedupe/manager/state.ts
+++ b/components/artists/dedupe/manager/state.ts
@@ -7,7 +7,7 @@ export type State = {
   /** The current step in the wizard-style dedupe process */
   currentStep: Step
 
-  /** The Artist record for which are managing dupes */
+  /** The Artist record for which we are managing dupes */
   artist: Artist | null
 
   /** The cluster of dupes for this Artist (may include the Artist record itself) */

--- a/components/artists/dedupe/manager/state.ts
+++ b/components/artists/dedupe/manager/state.ts
@@ -20,7 +20,10 @@ export type State = {
   badIds: BsonID[]
 
   /** A map indicating if any of the bad records’ values should be used to override the corresponding value in the good record */
-  overrides: Record<SimpleField, BsonID | null>
+  overrides: Record<SingleValuedField, BsonID | null>
+
+  /** A map indicating if any of the bad records’ values should be additively merged into the corresponding values in the good record */
+  additions: Record<MultiValuedField, BsonID[]>
 }
 
 /**
@@ -44,13 +47,23 @@ export enum Step {
 /**
  * A list of simple attributes that can be kept or overriden
  */
-export type SimpleField =
+export type SingleValuedField =
   | "gender"
   | "nationality"
   | "birthday"
   | "deathday"
   | "hometown"
   | "location"
+
+/**
+ * A list of related attributes or entities that can be merged, cumulatively,
+ * from "bad" records into the "good" record.
+ *
+ * (At the datasbase level these may ultimately be different instances, as in artworks.
+ * Or they may just be different values in an array or delimited field, as in alternate names.
+ * The de-duping tool need not know which.)
+ */
+export type MultiValuedField = "artworks" | "follows"
 
 /**
  * Used for initializing or resetting the app's state
@@ -69,6 +82,10 @@ export const initialState: State = {
     hometown: null,
     location: null,
   },
+  additions: {
+    artworks: [],
+    follows: [],
+  },
 }
 
 /**
@@ -77,7 +94,13 @@ export const initialState: State = {
 export type Action =
   | { type: "keep artist"; id: BsonID }
   | { type: "discard artist"; id: BsonID }
-  | { type: "prefer value"; fieldName: string; recordId: BsonID | null }
+  | {
+      type: "prefer value"
+      fieldName: SingleValuedField
+      recordId: BsonID | null
+    }
+  | { type: "add value"; fieldName: MultiValuedField; recordId: BsonID }
+  | { type: "remove value"; fieldName: MultiValuedField; recordId: BsonID }
   | { type: "reset" }
   | { type: "continue to step"; step: Step }
 
@@ -110,6 +133,27 @@ export const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         overrides: { ...state.overrides, [action.fieldName]: action.recordId },
+      }
+    case "add value":
+      return {
+        ...state,
+        additions: {
+          ...state.additions,
+          [action.fieldName]: [
+            ...state.additions[action.fieldName as MultiValuedField],
+            action.recordId,
+          ],
+        },
+      }
+    case "remove value":
+      return {
+        ...state,
+        additions: {
+          ...state.additions,
+          [action.fieldName]: state.additions[
+            action.fieldName as MultiValuedField
+          ].filter((id) => id !== action.recordId),
+        },
       }
     default:
       return state

--- a/components/artists/dedupe/types.ts
+++ b/components/artists/dedupe/types.ts
@@ -19,6 +19,10 @@ export type Artist = {
   deathday: string
   hometown: string
   location: string
+  counts: {
+    artworks: number
+    follows: number
+  }
 }
 
 /** An Artist record that also contains a list of potential dupes for that record. */

--- a/pages/artists/dedupe/[slug].tsx
+++ b/pages/artists/dedupe/[slug].tsx
@@ -1,8 +1,8 @@
 import { useRouter } from "next/router"
 
-import { ArtistDupesManager } from "../../../components/artists/dedupe/manager/ArtistDupesManager"
 import { useMetaphysics } from "../../../lib/artsy-next-auth"
 import type { ArtistWithDupes } from "../../../components/artists/dedupe/types"
+import { ArtistDupesManager } from "../../../components/artists/dedupe/manager/ArtistDupesManager"
 
 export default function Page() {
   const router = useRouter()
@@ -29,7 +29,11 @@ export default function Page() {
         deathday
         hometown
         location
-    }
+        counts {
+          artworks
+          follows
+        }
+      }
     `,
     {
       id: slug,


### PR DESCRIPTION
- Adds UX support for multi-valued fields, i.e. those that have 1-to-many relationship with an artist, such as artworks and follows

- Originally these fields were toggle-able, so that the admin could choose which associations to merge, but we simplified so that **all** associations from "bad" records will get merged (so as not to create any orphaned data)

- Unlike with simple single-valued attributes, we combine many of these and merge them into the destination "good" record

- This will be primarily used for associations rather than attributes, but could also be used for certain array-valued attributes such as _alternate names_, or _alternate nationalities_

- Note the **artworks** and **follows** fields at bottom of the screencap below…

![multi gif 5 128](https://user-images.githubusercontent.com/140521/154763090-1edd6912-232d-4474-8de7-a0b7b1e64672.gif)

