### PR TITLE
feat(dedupe): add confirmation screen before committing changes

### DIFF
--- a/components/artists/dedupe/manager/ArtistDupesManager.tsx
+++ b/components/artists/dedupe/manager/ArtistDupesManager.tsx
@@ -5,6 +5,7 @@ import { initialState, reducer, Step } from "./state"
 import { SelectGoodRecord } from "./SelectGoodRecord"
 import { SelectBadRecords } from "./SelectBadRecords"
 import { SelectFields } from "./SelectFields"
+import { Confirm } from "./Confirm"
 import { Debug } from "./Debug"
 
 interface Props {
@@ -39,6 +40,9 @@ export const ArtistDupesManager: React.FC<Props> = ({ artist }) => {
       break
     case Step.SELECT_FIELDS:
       currentStepUI = <SelectFields state={state} dispatch={dispatch} />
+      break
+    case Step.CONFIRM:
+      currentStepUI = <Confirm state={state} dispatch={dispatch} />
       break
     default:
       currentStepUI = <span>Hmm did not see that coming 🤔</span>

--- a/components/artists/dedupe/manager/Confirm.tsx
+++ b/components/artists/dedupe/manager/Confirm.tsx
@@ -1,0 +1,150 @@
+import React, { Dispatch, useState } from "react"
+import { Action, RecordStatus, SingleValuedField, State } from "./state"
+import { ArtistCardHeader } from "./ArtistCardHeader"
+import { Artist } from "../types"
+
+interface Props {
+  state: State
+  dispatch: Dispatch<Action>
+}
+
+/**
+ * Final step: confirm before sending merge payload to Gravity
+ */
+export const Confirm: React.FC<Props> = ({ state }) => {
+  const [payload, setPayload] = useState<Payload>()
+
+  const mergedArtist = deriveMergedArtistRecord(state)
+  const badArtists = getBadArtists(state)
+
+  return (
+    <div>
+      <div data-testid="confirmation">
+        <p className="my-1">
+          The following merged artist record will also receive artworks and
+          follows from the discarded record(s):{" "}
+          <code>{badArtists.map((a) => a.slug).join(", ")}</code>
+        </p>
+
+        <p className="my-1">Would you like to proceed?</p>
+
+        <button
+          className="bg-black100 text-white100 p-1 my-2 rounded-lg"
+          onClick={async () => {
+            const payload = getPayload(state)
+            setPayload(payload)
+          }}
+        >
+          Ok, proceed
+        </button>
+      </div>
+
+      {/* temporary */}
+      {payload && (
+        <div className="my-2">
+          <p className="my-2">Ok, Gravity. Here is your payload:</p>
+          <pre className="">{JSON.stringify(payload, null, 2)}</pre>
+        </div>
+      )}
+
+      <div>
+        <ArtistCardHeader
+          artist={mergedArtist}
+          recordStatus={RecordStatus.GOOD}
+        />
+
+        <ConfirmedField fieldName="gender" fieldValue={mergedArtist.gender} />
+
+        <ConfirmedField
+          fieldName="nationality"
+          fieldValue={mergedArtist.nationality}
+        />
+
+        <ConfirmedField
+          fieldName="birthday"
+          fieldValue={mergedArtist.birthday}
+        />
+
+        <ConfirmedField
+          fieldName="deathday"
+          fieldValue={mergedArtist.deathday}
+        />
+
+        <ConfirmedField
+          fieldName="hometown"
+          fieldValue={mergedArtist.hometown}
+        />
+
+        <ConfirmedField
+          fieldName="location"
+          fieldValue={mergedArtist.location}
+        />
+      </div>
+    </div>
+  )
+}
+
+function deriveMergedArtistRecord(state: State): Artist {
+  const mergedArtist = state.dupes.find(
+    (artist) => artist.internalID === state.goodId
+  )
+  if (!mergedArtist) throw new Error("Good artist is missing")
+
+  // replace overriden fields
+  for (const field in state.overrides) {
+    const f = field as SingleValuedField
+    const preferredId = state.overrides[f]
+    if (preferredId) {
+      const preferredRecord = state.dupes.find(
+        (a) => preferredId === a.internalID
+      )
+      if (!preferredRecord)
+        throw new Error(`Preferred artist for ${field} is missing`)
+      mergedArtist[f] = preferredRecord[f]
+    }
+  }
+
+  // TODO: indicate additive fields?
+
+  return mergedArtist
+}
+
+function getBadArtists(state: State): Artist[] {
+  const badArtists = (state.badIds || []).map((id) => {
+    const badArtist = state.dupes.find((a) => a.internalID == id)
+    if (!badArtist) throw new Error("Bad artist is missing")
+    return badArtist
+  })
+  return badArtists
+}
+
+type Payload = {
+  good_id: State["goodId"]
+  bad_ids: State["badIds"]
+  overrides: State["overrides"]
+  additions: State["additions"]
+}
+
+function getPayload(state: State): Payload {
+  const { goodId, badIds, overrides, additions } = state
+  return {
+    good_id: goodId,
+    bad_ids: badIds,
+    overrides,
+    additions,
+  }
+}
+
+const ConfirmedField: React.FC<{
+  fieldName: string
+  fieldValue: string | number
+}> = ({ fieldName, fieldValue }) => {
+  return (
+    <div
+      className={`p-2 border border-t-0 last:rounded-b-lg border-black30 hover:bg-green5`}
+    >
+      <div className="text-xs text-black50">{fieldName}</div>
+      <div className="[min-height:2em]">{fieldValue}</div>
+    </div>
+  )
+}

--- a/components/artists/dedupe/manager/__tests__/Confirm.spec.tsx
+++ b/components/artists/dedupe/manager/__tests__/Confirm.spec.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+
+import { Confirm } from "../Confirm"
+import { State, initialState } from "../state"
+import artist from "../__fixtures__/artist-with-dupes"
+
+it("renders a card for the merged artist", () => {
+  const dispatch = jest.fn()
+
+  const goodArtist = artist.duplicates[0]
+  const badArtist = artist.duplicates[1]
+
+  const state: State = {
+    ...initialState,
+    goodId: goodArtist.internalID,
+    badIds: [badArtist.internalID],
+  }
+
+  render(
+    <Confirm
+      state={{ ...state, dupes: artist.duplicates }}
+      dispatch={dispatch}
+    />
+  )
+
+  expect(screen.getByTestId("header")).toHaveTextContent(goodArtist.name)
+  expect(screen.getByTestId("header")).toHaveTextContent(goodArtist.slug)
+
+  const confirmation = screen.getByTestId("confirmation")
+  expect(within(confirmation).getByText(badArtist.slug)).toBeInTheDocument()
+
+  expect(
+    screen.getByRole("button", { name: "Ok, proceed" })
+  ).toBeInTheDocument()
+})

--- a/components/artists/dedupe/manager/state.ts
+++ b/components/artists/dedupe/manager/state.ts
@@ -42,6 +42,7 @@ export enum Step {
   SELECT_GOOD_RECORD,
   SELECT_BAD_RECORD,
   SELECT_FIELDS,
+  CONFIRM,
 }
 
 /**


### PR DESCRIPTION
- Adds a confirmation screen where the merged artist can be previewed, before sending the update to Gravity
- (Screencap shows a temporary message about the Gravity payload, in lieu of the actual submit, which is waiting on backend support in Gravity)

![confirm gif 5 128](https://user-images.githubusercontent.com/140521/159195830-27f9d7f5-3103-439b-aaf4-9283e3a17d6a.gif)
